### PR TITLE
Add "team_mzla"(thunderbird team) to Staff scope.

### DIFF
--- a/src/scope.rs
+++ b/src/scope.rs
@@ -198,6 +198,7 @@ fn scope_from_claimset(claims_set: &Option<Vec<String>>) -> Option<Trust> {
         let scope = if groups.contains(&String::from("team_moco"))
             || groups.contains(&String::from("team_mofo"))
             || groups.contains(&String::from("team_mozillaonline"))
+            || groups.contains(&String::from("team_mzla"))
             || groups.contains(&String::from("hris_is_staff"))
             || groups.contains(&String::from("mozilliansorg_ghe_group_curators"))
         {


### PR DESCRIPTION
In order for "team_mzla" to correctly have staff permissions on peoplemo, it appears the group name needs to be included here.